### PR TITLE
Fixing partial JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ CohereError
 
 MissingAPIKeyError
 BlockWithoutServerSentEventsError
+IncompleteJSONReceivedError
 
 RequestError
 ```

--- a/components/errors.rb
+++ b/components/errors.rb
@@ -10,6 +10,7 @@ module Cohere
 
     class MissingAPIKeyError < CohereError; end
     class BlockWithoutServerSentEventsError < CohereError; end
+    class IncompleteJSONReceivedError < CohereError; end
 
     class RequestError < CohereError
       attr_reader :request, :payload

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -88,6 +88,8 @@ module Cohere
 
         method_to_call = request_method.to_s.strip.downcase.to_sym
 
+        partial_json = ''
+
         response = Faraday.new(request: @request_options) do |faraday|
           faraday.response :raise_error
         end.send(method_to_call) do |request|
@@ -105,16 +107,26 @@ module Cohere
                 raise_error.on_complete(env.merge(body: chunk))
               end
 
-              result = { event: safe_parse_json(chunk), raw: { chunk:, bytes:, env: } }
+              partial_json += chunk
 
-              callback.call(result[:event], result[:raw]) unless callback.nil?
+              parsed_json = safe_parse_json(partial_json)
 
-              results << result
+              if parsed_json
+                result = { event: parsed_json, raw: { chunk:, bytes:, env: } }
+
+                callback.call(result[:event], result[:raw]) unless callback.nil?
+
+                results << result
+
+                partial_json = ''
+              end
             end
           end
         end
 
         return safe_parse_json(response.body) unless server_sent_events_enabled
+
+        raise IncompleteJSONReceivedError, partial_json if partial_json != ''
 
         results.map { |result| result[:event] }
       rescue Faraday::ServerError => e
@@ -122,9 +134,9 @@ module Cohere
       end
 
       def safe_parse_json(raw)
-        raw.start_with?('{', '[') ? JSON.parse(raw) : raw
+        raw.to_s.lstrip.start_with?('{', '[') ? JSON.parse(raw) : nil
       rescue JSON::ParserError
-        raw
+        nil
       end
     end
   end

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -124,9 +124,7 @@ module Cohere
           end
         end
 
-        unless server_sent_events_enabled
-          return safe_parse_json_with_fallback_to_raw(response.body)
-        end
+        return safe_parse_json_with_fallback_to_raw(response.body) unless server_sent_events_enabled
 
         raise IncompleteJSONReceivedError, partial_json if partial_json != ''
 

--- a/static/gem.rb
+++ b/static/gem.rb
@@ -6,7 +6,7 @@ module Cohere
     version: '1.0.0',
     author: 'gbaptista',
     summary: 'Interact with Cohere AI.',
-    description: "A Ruby gem for interacting with Cohere AI platform.",
+    description: 'A Ruby gem for interacting with Cohere AI platform.',
     github: 'https://github.com/gbaptista/cohere-ai',
     gem_server: 'https://rubygems.org',
     license: 'MIT',

--- a/template.md
+++ b/template.md
@@ -657,6 +657,7 @@ CohereError
 
 MissingAPIKeyError
 BlockWithoutServerSentEventsError
+IncompleteJSONReceivedError
 
 RequestError
 ```


### PR DESCRIPTION
Sometimes the API returns incomplete JSON. When this happens, it should wait for the next chunk to receive the complete, parsable JSON.